### PR TITLE
feat: Cortex AI Functions + Tier-aware 임베딩 SP (#27)

### DIFF
--- a/docs/work/done/000027-cortex-ai-functions/00_issue.md
+++ b/docs/work/done/000027-cortex-ai-functions/00_issue.md
@@ -1,0 +1,145 @@
+# feat: Cortex AI Functions 구현 (AI_COMPLETE/AI_CLASSIFY/AI_EMBED)
+
+## 목적
+AI가 이사 등급 분류, 인사이트 요약, 벡터 검색을 해주는 Cortex AI Functions SQL을 구현한다.
+
+## 완료 기준
+- [x] AI_COMPLETE 인사이트 생성 SQL 작동 — `V_AI_DISTRICT_INSIGHTS` + `V_AI_STATE_SUMMARY` Snowflake 배포, 서초구 2024-12 정밀 Tier 3줄 액션 / 강남구 2026-04 근사 Tier 2줄 + 신뢰도 고지 모두 runtime 확인 (2026-04-09)
+- [x] AI_CLASSIFY 이사 등급 분류 SQL 작동 (ARRAY_CONSTRUCT 문법) — `V_AI_DEMAND_GRADE` 배포, 서초구 2024-12 → `'안정'` 반환, `:labels[0]::STRING` 추출 경로 검증
+- [x] AI_EMBED + 벡터 유사도 검색 SQL 작동 — `T_DISTRICT_EMBEDDINGS` 25행 + `SP_FIND_SIMILAR_DISTRICTS('11650',5)` → 중구 0.89 · 영등포 0.86 · 서대문 0.75 (벡터 의미 정합성 확인: MULTI_SOURCE 3구 상호 상위)
+- [x] Streamlit 연동 함수 구현 — `src/app/cortex.py` 4 공개 함수 + TypedDict + allowlist + bind 파라미터, pure-Python validator 11건 + runtime smoke 6건 PASS
+
+## 테스트 코드 (TDD — 먼저 작성)
+
+```sql
+-- test_12_cortex_ai.sql
+-- TC-01: AI_COMPLETE 호출 가능
+SELECT SNOWFLAKE.CORTEX.COMPLETE('mistral-large2', '서울 강남구 이사 수요 분석해줘') AS insight;
+-- EXPECTED: 비어있지 않은 문자열 반환
+
+-- TC-02: AI_CLASSIFY 등급 분류 (ARRAY_CONSTRUCT 문법)
+SELECT SNOWFLAKE.CORTEX.CLASSIFY(
+    '신규개통 150건, 전월 대비 +25%',
+    ARRAY_CONSTRUCT('긴급 — 즉시 마케팅 투입', '주의 — 모니터링 필요', '안정 — 일반 운영')
+) AS grade;
+-- EXPECTED: 3개 등급 중 하나 반환
+
+-- TC-03: AI_EMBED 벡터 생성
+SELECT SNOWFLAKE.CORTEX.EMBED('e5-base-v2', '강남구 아파트 시세') AS vec;
+-- EXPECTED: VECTOR 타입 반환, 차원 > 0
+
+-- TC-04: 실제 테이블 데이터로 AI_COMPLETE 호출
+SELECT SNOWFLAKE.CORTEX.COMPLETE('mistral-large2',
+    CONCAT('지역: ', v.INSTALL_CITY, ', 신규개통: ', v.OPEN_COUNT, '건. 분석해줘.')
+) AS insight
+FROM MOVING_INTEL.ANALYTICS.V_TELECOM_NEW_INSTALL v
+LIMIT 1;
+-- EXPECTED: 의미있는 분석 텍스트 반환
+```
+
+## 참조
+- `docs/specs/dev_spec.md` B4 (Cortex AI Functions)
+- AI_CLASSIFY 배열은 반드시 ARRAY_CONSTRUCT() 사용 (Python 리스트 `[]` 문법 아님)
+- 의존성: #21 (통합 마트)
+
+## 불변식
+- Cortex AI Functions는 US West Oregon 리전에서 전체 지원
+- AI_COMPLETE 모델: mistral-large2 (비용 효율)
+- AI_EMBED 모델: e5-base-v2
+
+## 작업 내역
+
+### 2026-04-08 — /ri 현황 점검
+- 브랜치: `feat/000027-cortex-ai-functions` (이슈 #27)
+- AC 진행: 0/4 (모두 미완료)
+- 단계: **구현 대기** — 미커밋 변경사항 없음, 작업 폴더(`00_issue.md`, `01_plan.md`)만 존재
+- 의존성 #21 통합 마트는 머지 완료(`2a60614`) — 본 이슈 착수 가능
+- 다음 액션: `sql/tests/test_12_cortex_ai.sql` 작성(Red) → AI_COMPLETE/CLASSIFY/EMBED 래퍼 → Streamlit 연동
+
+### 2026-04-09 — Green 완료 스냅샷 (Python connector 직접 실행)
+- Snowflake MCP 끊김 → `snowflake-connector-python` 으로 우회 (`~/.snowflake/connections.toml [default]`)
+- 스크래치 스크립트 (`.omc/research/scratch-27/`, gitignored):
+  - `v0_sanity.py`/`v0_sanity2.py`/`v0_sanity3.py` — 전제 조건 검증 (Oregon, MART DATA_TIER 3:22, AI_COMPLETE/AI_EMBED 활성화, RICHGO 커버리지)
+  - `deploy_cortex.py` — `sql/cortex/001~003.sql` 순차 실행
+  - `run_tests.py` — `sql/test/test_12_cortex_ai.sql` TC-01~TC-06 수동 split 실행 + PASS/FAIL 판정
+  - `smoke_cortex_helpers.py` — `src/app/cortex.py` 순수 검증자 테스트 + 뷰/SP runtime 호출
+- **배포 결과 (Snowflake 실제 생성):**
+  - `V_AI_DISTRICT_INSIGHTS`, `V_AI_STATE_SUMMARY` ✓
+  - `V_AI_DEMAND_GRADE` ✓
+  - `T_DISTRICT_EMBEDDINGS` (VECTOR(FLOAT, 1024) × 25행) ✓
+  - `SP_REFRESH_DISTRICT_EMBEDDINGS` / `SP_FIND_SIMILAR_DISTRICTS` ✓
+  - 초기 로드: `T_DISTRICT_EMBEDDINGS refreshed (latest_ym=202604, rows=25)`
+- **TC-01~TC-06 결과 (`.omc/research/scratch-27/run_tests.log`):** PASS 6 / FAIL 0
+  - TC-01 AI_COMPLETE "안녕하세요" · 2.9s
+  - TC-02 AI_CLASSIFY `'안정'` · 0.6s
+  - TC-03 AI_EMBED NOT NULL · 0.6s
+  - TC-04 송파구 1151건 → 3줄 B2B 액션 아이템 · 5.1s
+  - TC-05 강남-서초 0.837, 강남-해운대 0.504 (벡터 의미 정합) · 1.9s
+  - TC-06 "송파구 1145건 최고, 종로구 258건 최저" · 2.7s
+- **AC-04 runtime smoke (`smoke_cortex_helpers.log`):** PASS 17 / FAIL 0
+  - Pure Python validators 11건 (allowlist 25구 · city_code/year_month 경계 조건)
+  - Runtime 6건 (서초 MULTI_SOURCE 3줄 액션 · 강남 TELECOM_ONLY 신뢰도 고지 · AI_CLASSIFY 서초 '안정' · SP_FIND_SIMILAR 서초 top-5: 중구 0.89 영등포 0.86 서대문 0.75 · AI_AGG 202412 25구 요약 · T_DISTRICT_EMBEDDINGS 25행)
+- **데이터 한계 관찰 (신규 발견):**
+  - `V_RICHGO_MARKET_PRICE` 및 SPH 소스 월 범위 최대 = `202412`
+  - `MART_MOVE_ANALYSIS` 월 범위 = `202307~202604` (34개월)
+  - → MULTI_SOURCE 3구의 4종 시그널(평당가·상주인구·카드매출·신규주거잔고)은 2024-12까지만 완전
+  - 현재 `SP_REFRESH_DISTRICT_EMBEDDINGS`는 `MAX(STANDARD_YEAR_MONTH)=202604` 기준 → 3구 프로필 텍스트에 "0원/N/A" 포함 → 임베딩 품질 약화 가능성
+  - 벡터 유사도 검증 결과 정성적으로는 여전히 정합(중구·영등포·서초가 상위 군집) → **후속 개선 후보** (#28/#29 이슈 또는 별도 hotfix)
+- **본 이슈 안에서 추가로 처리한 개선 (SP Tier-aware 기준월 분기):**
+  1. `sql/cortex/003_cortex_ai_embed.sql` — `SP_REFRESH_DISTRICT_EMBEDDINGS` 재작성: `multi_ym = MAX(YM WHERE DATA_TIER='MULTI_SOURCE' AND AVG_MEME_PRICE IS NOT NULL)` / `telecom_ym = MAX(YM WHERE DATA_TIER='TELECOM_ONLY')`
+  2. `T_DISTRICT_EMBEDDINGS` — `PROFILE_YM VARCHAR(6)` 컬럼 추가 (`ALTER TABLE ... ADD COLUMN IF NOT EXISTS` 로 idempotent), 관측성 확보
+  3. `sql/cortex/.ai.md` — "임베딩 Tier별 기준월" 섹션 추가
+  4. 재배포 결과: `T_DISTRICT_EMBEDDINGS refreshed (multi_ym=202412, telecom_ym=202604, rows=25)` — MULTI_SOURCE 3구 → 202412, TELECOM_ONLY 22구 → 202604 실측 확인
+  5. **품질 개선 효과 (`verify_tier_aware.log`):**
+     - 이전: 서초구 프로필 "신규개통 X건, 상주인구 0명, 가전매출 0원, 평당 N/A원"
+     - 지금: 서초구 프로필 "신규개통 462건, 상주인구 3962711명, 가전매출 9454712863원, 신규주거잔고 1620건, 평당 7181원"
+     - 서초구 유사 top-5: 이전 `중구 0.89 · 영등포 0.86 · 서대문 0.75` → 지금 `중구 0.908 · 영등포 0.859 · 서대문 0.653 · 중랑 0.636 · 성동 0.622`
+     - **Tier 간 분리도 향상** (다른 Tier 유사도 0.75 → 0.65), **같은 Tier 응집도 향상** (0.89 → 0.91)
+     - 강남구(TELECOM_ONLY) top-5: 동작 0.899 · 강북 0.897 · 광진 0.893 · 강동 0.889 · 용산 0.888 — 전부 TELECOM_ONLY 22구 내에서 매칭, Tier 경계가 임베딩 공간에 반영됨
+  6. 회귀 검증: `run_tests.py` 6/6 PASS + `smoke_cortex_helpers.py` 17/17 PASS 재실행 확인
+- **권장 후속 작업 (본 이슈 범위 외):**
+  1. `@st.cache_data(ttl=3600)` 적용 위치: `src/app/cortex.py` 4 공개 함수 (#28 Streamlit 시점에서 wrapping)
+  2. `gh issue edit 27 --body-file 00_issue.md` — finish-issue 단계에서 1회 동기화 (stale `mistral-large2`/`e5-base-v2` 표기 제거)
+  3. dev_spec.md B4 AI_EMBED 섹션 L1710~1750 예시 코드가 `UPDATE RICHGO_MARKET_PRICE SET EMBEDDING=...` 패턴 — Marketplace read-only 불변식 위반. 별도 hotfix 또는 #40 후속으로 분리 처리 권장
+- **AC 최종:** 4/4 PASS + AC-05 권고(AI_AGG TC-06 통해 커버됨) + SP Tier-aware 품질 개선 1건
+
+### 2026-04-09 — /simplify 3-agent 리뷰 + 정리 패스
+3개 리뷰 에이전트 병렬 (reuse / quality / efficiency). 실 버그/개선 5건 처리, scope creep 제안 다수 deferred.
+- **`001_cortex_ai_insights.sql`** — `mart_with_richgo` CTE 삭제. MART에 이미 `AVG_MEME_PRICE` 컬럼 있음에도 V_RICHGO + V_BJD_DISTRICT_MAP을 correlated subquery로 재집계 중이었음 (003은 이미 올바르게 `m.AVG_MEME_PRICE` 직접 사용). 850행 × Marketplace 재JOIN 비용 제거 + 의존성 단순화.
+- **`001`, `002`, `003` 공통** — 파일 상단에 "⚠ 비용 주의: 뷰 SELECT마다 AI 호출 / WHERE (CITY_CODE, STANDARD_YEAR_MONTH) 필터 필수 / SELECT * 금지" 경고 헤더 추가.
+- **`002_cortex_ai_classify.sql`** — `YOY_PCT` 계산이 SELECT 프로젝션과 AI_CLASSIFY 프롬프트 양쪽에 중복되어 drift 위험. `with_yoy` 단일 CTE로 통합.
+- **`003_cortex_ai_embed.sql`** — 전환기용 `ALTER TABLE ... ADD COLUMN IF NOT EXISTS PROFILE_YM` 삭제. 본 이슈가 첫 커밋이라 새 배포는 CREATE 단일 경로만 존재, ALTER는 dead code.
+- **`src/app/cortex.py`** — 미사용 `MULTI_SOURCE_CITIES` 상수 삭제 (Tier 분류는 `MART.DATA_TIER` 컬럼에서 직접 온다, 주석 보강). `_validate_year_month`: `None`/`isascii`/월 1-12 범위 체크 추가 (기존 `isdigit`은 fullwidth `２０２４１２` 통과 위험).
+- **`sql/cortex/.ai.md`** — 의존성 목록 업데이트 (RICHGO/BJD 제거, MART 단일 의존).
+- **회귀 재검증:**
+  - 재배포: `T_DISTRICT_EMBEDDINGS refreshed (multi_ym=202412, telecom_ym=202604, rows=25)` 동일 결과
+  - `run_tests.py` TC-01~06 **PASS 6/0** (`run_tests.log`)
+  - `smoke_cortex_helpers.py` **PASS 19/0** (Pure Python 13 + Runtime 6) — 경계 케이스 3건(`202413`, `202400`, `２０２４１２`) 추가 거부 확인
+- **Deferred (scope creep / 후속 대상):**
+  - DataTier/DemandGrade StrEnum 도입 (#28 Streamlit 통합 시)
+  - AI 결과 캐시 테이블 `T_AI_*_CACHE` + 월간 TASK (별도 이슈)
+  - `WHEN NOT MATCHED BY SOURCE THEN DELETE` (Seoul 25구 안정, 리스크 낮음)
+  - `V_AI_DISTRICT_FULL` 결합 뷰 (Streamlit 호출 round-trip 절감, #28 시점)
+  - dev_spec.md B4 L1711~1757 `ALTER/UPDATE RICHGO` 예시 정정 (Marketplace 불변식 위반, 별도 hotfix)
+- **다음 단계:** `/finish-issue 27`
+
+### 2026-04-08 — /ri 복구 스냅샷 (세션 튕김 후)
+- 브랜치: `feat/000027-cortex-ai-functions` · 이전 이후 신규 커밋 0건 (모두 미커밋 상태)
+- 단계: **구현 중 (Green 검증 대기)** — 산출물은 전부 디스크에 존재하나 Snowflake 실행 검증 증거 없음
+- 현재 디스크 산출물 (563 라인 / 전부 untracked):
+  - `sql/cortex/.ai.md` — 디렉토리 목적·Dual-Tier 원칙·함수 네임스페이스 불변식
+  - `sql/cortex/001_cortex_ai_insights.sql` (128 L) — `V_AI_DISTRICT_INSIGHTS` + `V_AI_STATE_SUMMARY` (AI_COMPLETE + AI_AGG, DATA_TIER CASE 분기)
+  - `sql/cortex/002_cortex_ai_classify.sql` (69 L) — `V_AI_DEMAND_GRADE` (AI_CLASSIFY 짧은 라벨 3종, `:labels[0]::STRING`)
+  - `sql/cortex/003_cortex_ai_embed.sql` (157 L) — `T_DISTRICT_EMBEDDINGS`(VECTOR(FLOAT,1024)) + `SP_REFRESH_DISTRICT_EMBEDDINGS` + `SP_FIND_SIMILAR_DISTRICTS` + 말미 CALL 초기 로드
+  - `sql/test/test_12_cortex_ai.sql` (56 L) — TC-01~TC-06 Red/Green
+  - `src/app/.ai.md` — Streamlit 루트 목적·공개 API 표·보안 불변식
+  - `src/app/cortex.py` (153 L) — 4 공개 함수(`get_district_insight` / `classify_demand` / `find_similar_districts` / `aggregate_state_summary`) + TypedDict + allowlist(25구) + bind 파라미터
+- 미완료 항목:
+  - Snowflake MCP 연결 끊김(`proofKey` 에러) → V0 사전검증 7건 + `sql/cortex/` 3파일 실행 + TC-01~06 Green 확인 미수행
+  - `CALL SP_REFRESH_DISTRICT_EMBEDDINGS()` 25행 초기 로드 미확인
+  - PR 본문용 AI_COMPLETE 실행 시간/비용 추정(R3 완화 증거) 미측정
+- 다음 액션 (우선순위 순):
+  1. Snowflake MCP 재연결 (사용자 액션 필요) → `/restart`에 준하는 설정 확인
+  2. `sql/cortex/001 → 002 → 003` 순서대로 실행 + `CALL SP_REFRESH_DISTRICT_EMBEDDINGS()`
+  3. `sql/test/test_12_cortex_ai.sql` TC-01~TC-06 Green 확인
+  4. `finish-issue` 전 `gh issue edit 27 --body-file 00_issue.md` 로 stale 모델명(`mistral-large2`/`e5-base-v2`) → `claude-4-sonnet`/`snowflake-arctic-embed-l-v2.0` 동기화

--- a/docs/work/done/000027-cortex-ai-functions/01_plan.md
+++ b/docs/work/done/000027-cortex-ai-functions/01_plan.md
@@ -1,0 +1,254 @@
+# 01_plan: Cortex AI Functions 구현 (Issue #27)
+
+> Branch `feat/000027-cortex-ai-functions` · 작성 2026-04-08 (team `plan-27-cortex`: spec-aligner + impl-architect + compat-critic)
+> SoT: `docs/specs/dev_spec.md` B4 (line 1599~1770, 2026-04-08 #40 재작성본)
+> 병렬 리서치 산출물:
+> - `.omc/research/27-plan-spec-alignment.md` (정정안 15건 + Red 테스트 6 TC)
+> - `.omc/research/27-plan-impl-architecture.md` (937줄 — 3개 SQL + cortex.py 전체 본문)
+> - `.omc/research/27-plan-compatibility.md` (의존성 그래프 + 리스크 10건 + Snowflake 사전 검증 7건)
+
+---
+
+## 0. 상황 요약 — 왜 01_plan.md를 재작성하는가
+
+Issue #27 body(`00_issue.md`) + 기존 01_plan.md는 **#40 dev_spec 재작성 이전에 작성되어 stale**이다. 아래 5건은 즉시 교체 대상:
+
+| # | stale 표기 | #40 이후 SoT |
+|---|-----------|-------------|
+| 1 | `mistral-large2` | `claude-4-sonnet` |
+| 2 | `e5-base-v2` | `snowflake-arctic-embed-l-v2.0` (`VECTOR(FLOAT, 1024)`) |
+| 3 | `SNOWFLAKE.CORTEX.COMPLETE/CLASSIFY/EMBED` (네임스페이스) | `AI_COMPLETE / AI_CLASSIFY / AI_AGG / AI_EMBED` (GA, 접두사 없음) |
+| 4 | `'서울특별시'` (일부 예시) | `INSTALL_STATE = '서울'` (#40 Snowflake 직검증 정정) |
+| 5 | `sql/tests/test_12_cortex_ai.sql` (복수형) | `sql/test/test_12_cortex_ai.sql` (본 레포 실경로) |
+
+**전략:** 본 01_plan.md를 SoT 기준으로 전면 재작성하고, finish 단계에서 `00_issue.md` + `gh issue edit 27 --body-file` 로 1회 동기화한다.
+
+---
+
+## 1. AC 체크리스트 (재작성)
+
+Issue #27 AC는 유지하되, 모델명·함수명·경로를 SoT 기준으로 교체한다. AI_AGG를 선택 AC로 추가(B4 MVP 4함수 커버리지 확보).
+
+- [ ] **AC-01 · AI_COMPLETE 인사이트 생성 SQL 작동** — `AI_COMPLETE('claude-4-sonnet', <prompt>)` 호출로 비어있지 않은 한국어 문자열 반환. 실데이터(`V_TELECOM_NEW_INSTALL` + `MART_MOVE_ANALYSIS`) 기반 1행 이상 Green.
+- [ ] **AC-02 · AI_CLASSIFY 이사 등급 분류 SQL 작동** — `AI_CLASSIFY(input, ARRAY_CONSTRUCT('긴급 — …','주의 — …','안정 — …'))` 가 3개 라벨 중 하나를 반환. Python 리스트 `[]` 문법 금지.
+- [ ] **AC-03 · AI_EMBED + 벡터 유사도 검색 SQL 작동** — `AI_EMBED('snowflake-arctic-embed-l-v2.0', <text>)` 가 `VECTOR(FLOAT, 1024)` 반환, `VECTOR_COSINE_SIMILARITY` 로 유사 구 top-5 조회 가능.
+- [ ] **AC-04 · Streamlit 연동 함수 구현** — `src/app/cortex.py` 4개 공개 함수(`get_district_insight` / `classify_demand` / `find_similar_districts` / `aggregate_state_summary`) 구현 + Dual-Tier 배지 반환.
+- [ ] **AC-05 (권고) · AI_AGG 시군구 트렌드 요약 SQL 작동** — B4 MVP 4함수 커버리지. Red 테스트 TC-06로 검증.
+
+---
+
+## 2. 테스트 체크리스트 (TDD · `sql/test/test_12_cortex_ai.sql` · Red → Green)
+
+Red SQL 전문은 `.omc/research/27-plan-spec-alignment.md` §3에 준비됨. 파일에 그대로 붙여넣어 실행.
+
+- [ ] **TC-01** · `AI_COMPLETE('claude-4-sonnet', '한국어로 "안녕하세요"…')` → `LENGTH(result) > 0` — **모델 활성화 검증(R6)** 겸용
+- [ ] **TC-02** · `AI_CLASSIFY('신규개통 150건, +25%', ARRAY_CONSTRUCT(…3개…))` → 결과 ∈ {긴급,주의,안정}
+- [ ] **TC-03** · `AI_EMBED('snowflake-arctic-embed-l-v2.0', …)` → `TYPEOF LIKE 'VECTOR(FLOAT%1024%'` + NOT NULL
+- [ ] **TC-04** · `V_TELECOM_NEW_INSTALL WHERE INSTALL_STATE='서울' LIMIT 1` 행을 프롬프트에 CONCAT → `AI_COMPLETE` 결과 LENGTH > 0
+- [ ] **TC-05** · `VECTOR_COSINE_SIMILARITY(강남-서초, 강남-해운대)` → 두 값 FLOAT NOT NULL + 강남-서초 ≥ 강남-해운대
+- [ ] **TC-06** · `AI_AGG(MART_MOVE_ANALYSIS 최신월 25구 concat, …)` → 1행 + summary LENGTH > 0
+
+Python 통합 테스트는 선택 (`tests/test_12_cortex_ai.py`). CI 스모크는 SQL 6 TC로 충분.
+
+---
+
+## 3. 파일 구조 (산출물)
+
+```
+sql/cortex/                               ← 신규 디렉토리 (dev_spec A8 매핑)
+├── .ai.md                                (신규) 목적·뷰/테이블/SP 목록·Dual-Tier 분기
+├── 001_cortex_ai_insights.sql            (신규) V_AI_DISTRICT_INSIGHTS + V_AI_STATE_SUMMARY
+├── 002_cortex_ai_classify.sql            (신규) V_AI_DEMAND_GRADE
+└── 003_cortex_ai_embed.sql               (신규) T_DISTRICT_EMBEDDINGS + SP_REFRESH + SP_FIND_SIMILAR
+
+sql/test/
+└── test_12_cortex_ai.sql                 (신규) Red → Green 6 TC
+
+src/app/                                  ← 신규 디렉토리 (dev_spec A8 C1~C5 매핑)
+├── .ai.md                                (신규) Streamlit 앱 구조 — 본 이슈는 cortex.py만
+└── cortex.py                             (신규) Snowpark 헬퍼 4 함수 + allowlist + TypedDict
+
+tests/ (선택)
+└── test_12_cortex_ai.py                  (선택) cortex.py 함수 실호출 스모크
+```
+
+**번호 규칙 결정:** `sql/cortex/`는 `sql/views/`(002~005)와 독립 네임스페이스로 **001부터** 시작. 근거 = dev_spec A8 L2906 디렉토리 분리 매핑. 테스트 번호 `test_12`는 이슈-테스트 1:1(#27→12) 규칙 유지.
+
+---
+
+## 4. 데이터베이스 객체 (완성 후 MOVING_INTEL.ANALYTICS 내 추가 객체)
+
+| 종류 | 이름 | 의존성 | 역할 |
+|------|------|--------|------|
+| VIEW | `V_AI_DISTRICT_INSIGHTS` | MART_MOVE_ANALYSIS · V_RICHGO_MARKET_PRICE · V_BJD_DISTRICT_MAP | 25구 × 월 AI_COMPLETE 인사이트. `CASE DATA_TIER` 분기 프롬프트. |
+| VIEW | `V_AI_STATE_SUMMARY` | MART_MOVE_ANALYSIS | 서울 월별 AI_AGG 자연어 요약. |
+| VIEW | `V_AI_DEMAND_GRADE` | MART_MOVE_ANALYSIS | 25구 × 월 AI_CLASSIFY 3등급 (allowlist: 긴급/주의/안정). |
+| TABLE | `T_DISTRICT_EMBEDDINGS` | MART_MOVE_ANALYSIS · V_RICHGO_MARKET_PRICE · V_BJD_DISTRICT_MAP | 25행 × `VECTOR(FLOAT, 1024)` 지역 프로필. ~100KB. |
+| PROCEDURE | `SP_REFRESH_DISTRICT_EMBEDDINGS()` | T_DISTRICT_EMBEDDINGS | MERGE 증분 — 최신월 기준 재계산. |
+| PROCEDURE | `SP_FIND_SIMILAR_DISTRICTS(target_city_code, top_k)` | T_DISTRICT_EMBEDDINGS | RESULTSET 반환 — 유사 구 top_k. |
+
+**MART_MOVE_ANALYSIS에는 ALTER 금지** — `T_DISTRICT_EMBEDDINGS` 별도 테이블로 분리(R1·R2 해소). #22 MOVE_SIGNAL_INDEX 컬럼 추가와 충돌 없음.
+
+---
+
+## 5. Dual-Tier 분기 매트릭스
+
+| 항목 | MULTI_SOURCE 3구 (11140·11560·11650) | TELECOM_ONLY 22구 |
+|------|--------------------------------------|-------------------|
+| 데이터 소스 | OPEN_COUNT · ELECTRONICS_FURNITURE_SALES · TOTAL_RESIDENTIAL_POP · NEW_HOUSING_BALANCE_COUNT · RICHGO 평당가 (5종) | OPEN_COUNT · RICHGO 평당가 (2종) |
+| AI_COMPLETE 프롬프트 | `[정밀 Tier] …4종 시그널 종합…B2B 3줄 번호 액션` | `[근사 Tier] …통신 단일 소스 경량…2줄, 첫 줄 "데이터 신뢰도: 근사"` |
+| AI_EMBED 프로필 텍스트 | 4종 시그널 + 평당가 | OPEN_COUNT + 평당가 |
+| UI 배지 | 🎯 정밀 Tier (4종 시그널) | ⚡ 근사 Tier (통신 단일) |
+| 분기 위치 | SQL `CASE DATA_TIER WHEN 'MULTI_SOURCE' THEN … ELSE …` (뷰 본문) | 동일 |
+| Python 역할 | 배지 부착만 — 프롬프트는 SQL에서 확정 | 동일 |
+
+**원칙:** 프롬프트 수정은 SQL 파일 한 곳(`001_cortex_ai_insights.sql`, `003_cortex_ai_embed.sql`)에서만. Python은 결과 포맷팅·배지만 담당.
+
+---
+
+## 6. Streamlit 헬퍼 API (`src/app/cortex.py`)
+
+| 함수 | 시그니처 | 반환 | 소비 이슈 |
+|------|---------|------|-----------|
+| `get_district_insight` | `(session, city_code, year_month) -> DistrictInsight` | TypedDict(`ai_insight`, `data_tier`, `tier_badge`, `open_count`, `yoy_pct`) | #28 Streamlit 히트맵 — 행정동 클릭 시 상세 패널 |
+| `classify_demand` | `(session, city_code, year_month) -> DemandGrade` | TypedDict(`demand_grade` ∈ allowlist 3개) | #28 히트맵 색상/범례 보조 |
+| `find_similar_districts` | `(session, city_code, top_k=5) -> list[SimilarDistrict]` | list[TypedDict(`similarity`, `city_name`, `data_tier`)] | #29 Streamlit 세그먼트 — "유사 지역 5개" 탭 |
+| `aggregate_state_summary` | `(session, install_state='서울', year_month) -> str` | 한국어 요약 1문단 | #29 보조 카드 (선택) |
+
+**보안·안정성 3중 방어:**
+1. `SEOUL_CITY_CODES: frozenset` + `_validate_city_code()` — allowlist 25구만 허용
+2. `_validate_year_month()` — 6자리 숫자 정규식
+3. `session.sql(..., params=[...]).collect()` — bind 파라미터 (f-string SQL 금지)
+
+---
+
+## 7. 구현 순서 (TDD · 9단계)
+
+### 7.1 준비·검증 (블로커 차단)
+
+1. **[V0 사전검증 · Snowflake MCP]** — 구현 시작 전 아래 7개 쿼리를 1회 실행해 레이어별 가용성 확인.
+   - V1 `SELECT CURRENT_REGION()` → Oregon 확인
+   - V2 `DESCRIBE VIEW V_TELECOM_NEW_INSTALL` + `SELECT DISTINCT INSTALL_STATE` → `'서울'`
+   - V3 `DESCRIBE TABLE MART_MOVE_ANALYSIS` + `SELECT DATA_TIER, COUNT(DISTINCT CITY_CODE)` → `MULTI_SOURCE=3 / TELECOM_ONLY=22`
+   - V4 `SELECT AI_COMPLETE('claude-4-sonnet', 'ping')` → **R6 해소**
+   - V5 `SELECT TYPEOF(AI_EMBED('snowflake-arctic-embed-l-v2.0', 'test'))` → `'VECTOR(FLOAT, 1024)'` **R6 해소**
+   - V6 `JOIN V_RICHGO_MARKET_PRICE × V_BJD_DISTRICT_MAP` — 3구 매칭
+   - V7 AI_COMPLETE 1행 샘플 실행 시간 측정 — **R3 비용 추정**
+   - **실패 시 대응:** `.omc/research/27-plan-spec-alignment.md` §5.1 분기표 참조. 모델 미활성화 시 대체 모델(`claude-3-5-sonnet` 등) 승인 프로세스로 에스컬레이션.
+
+2. **Issue body + 01_plan.md 정정** — 본 문서는 이미 반영됨. `00_issue.md` 불변식 섹션은 finish 단계에서 `gh issue edit 27 --body-file` 과 함께 rewrite.
+
+### 7.2 Red 단계 (테스트 먼저)
+
+3. **`sql/test/test_12_cortex_ai.sql` 작성** — `27-plan-spec-alignment.md` §3의 6 TC SQL 그대로 파일에 저장. 이 시점에는 뷰가 없으므로 TC-04·TC-06만 참조 실패 가능, TC-01~03·05는 모델 ping 레벨로 통과할 수 있음(Cortex GA 전제).
+
+### 7.3 Green 단계 (구현)
+
+4. **`sql/cortex/.ai.md` 작성** — 디렉토리 목적·파일 역할·의존성·Dual-Tier 원칙 기술. CLAUDE.md 불변식: 모든 디렉토리 `.ai.md` 포함.
+
+5. **`sql/cortex/001_cortex_ai_insights.sql` 작성 + 실행** — `27-plan-impl-architecture.md` §2 본문 그대로. 뷰 2개(`V_AI_DISTRICT_INSIGHTS`, `V_AI_STATE_SUMMARY`) 생성. **TC-04, TC-06 Green 목표.**
+   - **주의:** 뷰 SELECT 시점마다 AI_COMPLETE 호출 → 검증은 단일 행 필터(`WHERE CITY_CODE='11680' AND STANDARD_YEAR_MONTH='202604'`)로만 실행.
+
+6. **`sql/cortex/002_cortex_ai_classify.sql` 작성 + 실행** — `V_AI_DEMAND_GRADE` 생성. AI_CLASSIFY GA 반환 스키마 실측: `OBJECT{label,score}` vs 직접 `STRING`. 실측 후 `:label::STRING` 캐스팅 유지 여부 결정. **TC-02 Green 목표.**
+
+7. **`sql/cortex/003_cortex_ai_embed.sql` 작성 + 실행** — `T_DISTRICT_EMBEDDINGS` + `SP_REFRESH_DISTRICT_EMBEDDINGS` + `SP_FIND_SIMILAR_DISTRICTS` 생성. 마지막에 `CALL SP_REFRESH_DISTRICT_EMBEDDINGS()` 로 25행 초기 로드. **TC-03, TC-05 Green 목표.**
+
+8. **`src/app/.ai.md` + `src/app/cortex.py` 작성** — `27-plan-impl-architecture.md` §5 본문 그대로. 4 함수 + TypedDict + allowlist + bind 파라미터. **AC-04 만족.**
+
+9. **(선택) `tests/test_12_cortex_ai.py` 작성** — 4 함수 실호출 1건씩 스모크. 세션 픽스처는 기존 `tests/test_06_snowpark.py` 패턴 재사용.
+
+### 7.4 마무리
+
+10. **전체 통합 검증** — `sql/test/test_12_cortex_ai.sql` 6 TC 전부 Green 확인 + `sql/cortex/` 전 파일 Snowflake 재실행 멱등성 확인.
+
+11. **`.ai.md` 최신화** — `sql/cortex/.ai.md`, `src/app/.ai.md`, 필요 시 `sql/views/.ai.md` 크로스 레퍼런스.
+
+12. **`scripts/check_invariants.py` 통과** (있는 경우) — 시크릿 하드코딩 0건, PII 실데이터 커밋 0건.
+
+13. **Issue body 동기화** — `finish-issue` 시점에 `gh issue edit 27 --body-file 00_issue.md` 로 stale 표기 제거 1회 반영. diff는 `.omc/research/27-plan-spec-alignment.md` §4.2 참조.
+
+---
+
+## 8. 의존성 그래프 (간략)
+
+```
+#19 V_TELECOM_NEW_INSTALL ──┐
+#17 V_RICHGO_MARKET_PRICE ──┼─→ #21 MART_MOVE_ANALYSIS ─→ #27 Cortex AI Functions ─┬─→ #28 Streamlit 히트맵
+#20 V_BJD_DISTRICT_MAP ─────┘                          (본 이슈)                    └─→ #29 Streamlit 세그먼트
+#40 dev_spec 정정 ─────────────────────────────────────→ #27
+                                                                    (병렬 독립) #22/#23/#24/#25/#26
+```
+
+**전체 그래프 + 10건 리스크 표:** `.omc/research/27-plan-compatibility.md` §1, §4 참조.
+
+---
+
+## 9. 호환성 결론 (compat-critic 요약)
+
+**#27 즉시 착수 가능. 블로커 없음.**
+
+- 10건 Input 의존성 모두 머지 완료(`2a60614`, `3cfafdb`) 또는 GA.
+- R1(MART 컬럼 충돌): T2 impl-architect가 `T_DISTRICT_EMBEDDINGS` 별도 테이블로 분리 — **해소**.
+- R2(Marketplace ALTER 금지): 본인 DB에 테이블 생성 — **해소**.
+- R4(Issue body stale): 본 01_plan.md rewrite + finish 단계 `gh issue edit` — **해소 경로 확정**.
+- R6(모델 활성화): 구현 첫 단계 V4·V5 쿼리로 검증 — **블로커 전환 가능, 조기 감지**.
+- R3(AI_COMPLETE 비용): 뷰 전수 SELECT 금지, 파라미터 기반 단일 행 호출 + Streamlit `@st.cache_data` 후속 이슈로 연결.
+- #28/#29 후속 이슈 body에 AI 호출 지점 명시 1건씩 필요 → finish 단계에서 spec-aligner 후속 sync 권고.
+
+---
+
+## 10. 불변식 (재작성)
+
+- **리전:** US West (Oregon, us-west-2). Cross-region inference 불필요.
+- **모델 3종 고정:** completion=`claude-4-sonnet`, embed=`snowflake-arctic-embed-l-v2.0`, 벡터 차원=`VECTOR(FLOAT, 1024)`.
+- **함수 네임스페이스 고정:** `AI_COMPLETE` / `AI_CLASSIFY` / `AI_AGG` / `AI_EMBED` / `VECTOR_COSINE_SIMILARITY` (GA, 접두사 없음). `SNOWFLAKE.CORTEX.*` 사용 금지.
+- **배열 문법:** `ARRAY_CONSTRUCT(...)` — Python 리스트 `[]` 금지.
+- **실데이터 필터:** `V_TELECOM_NEW_INSTALL.INSTALL_STATE = '서울'` (NOT `'서울특별시'`). `MART_MOVE_ANALYSIS` 는 `DATA_TIER` 기반 분기 유지.
+- **Marketplace 원본 쓰기 금지:** RICHGO 등 외부 공유 테이블 `ALTER` 금지. 벡터·파생 컬럼은 본인 DB(`MOVING_INTEL.ANALYTICS`)에 별도 테이블.
+- **테스트 경로:** `sql/test/test_12_cortex_ai.sql` (단수형, `sql/tests/` 아님).
+- **시크릿 하드코딩 금지:** `account`, `password`, `token` 소스코드 유입 금지. MCP/환경변수 사용.
+- **PII 커밋 금지:** 개인정보·실데이터 샘플 금지. 기대값(row count, 컬럼 존재)만 테스트에 명시.
+
+---
+
+## 11. 검증 · 완료 조건
+
+- [x] `sql/test/test_12_cortex_ai.sql` TC-01 ~ TC-06 전부 Green (Snowflake 직접 실행) — `.omc/research/scratch-27/run_tests.log` PASS 6/6 (2026-04-09)
+- [x] `V_AI_DISTRICT_INSIGHTS`, `V_AI_STATE_SUMMARY`, `V_AI_DEMAND_GRADE`, `T_DISTRICT_EMBEDDINGS` 객체 실존 확인 — `deploy_cortex.log` `successfully created.`
+- [x] `CALL SP_REFRESH_DISTRICT_EMBEDDINGS()` 성공 + `T_DISTRICT_EMBEDDINGS` 25행 — 초기 로드 반환 `"latest_ym=202604, rows=25"`
+- [x] `CALL SP_FIND_SIMILAR_DISTRICTS('11650', 5)` 5행 반환 — 중구 0.89·영등포 0.86·서대문 0.75·…·타겟 제외 확인 (`smoke_cortex_helpers.log`)
+- [x] `src/app/cortex.py` 4 함수 import 성공 + `_validate_city_code`/`_validate_year_month` 경계 테스트 — pure-Python validator 11건 PASS
+- [x] `sql/cortex/.ai.md`, `src/app/.ai.md` 최신화 — 두 파일 모두 초기 작성본이 현 상태와 일치
+- [ ] `scripts/check_invariants.py` 통과 (있는 경우) — finish-issue 시 확인
+- [ ] `docs/work/active/000027-cortex-ai-functions/00_issue.md` + GitHub Issue #27 body 동기화 — finish-issue 시 `gh issue edit 27 --body-file`
+- [ ] PR 본문에 AI_COMPLETE 1행당 실행 시간/비용 추정 기재 (R3 완화 증거) — finish-issue 시 작성 (TC-04 5.1s / V7 2.7s / TC-06 AI_AGG 2.7s 기록 사용)
+- [ ] `docs/work/done/000027-cortex-ai-functions/` 로 이동 (finish-issue 시)
+
+---
+
+## 12. 관련 파일 인덱스
+
+**입력 의존성 (읽기 전용):**
+- `docs/specs/dev_spec.md` L1599~1770 (B4), L2906 (A8), L2946~2989 (#40 변경 이력)
+- `pipelines/preprocessing.py` — MART_MOVE_ANALYSIS 생성 로직
+- `sql/views/002_richgo_views.sql`, `sql/views/003_sph_views.sql`, `sql/views/004_bjd_mapping.sql`, `sql/views/005_telecom_district_mapped.sql`
+- `sql/test/test_06_integrated_mart.sql` — MART 컬럼 실증
+
+**신규 산출물:**
+- `sql/cortex/.ai.md`
+- `sql/cortex/001_cortex_ai_insights.sql`
+- `sql/cortex/002_cortex_ai_classify.sql`
+- `sql/cortex/003_cortex_ai_embed.sql`
+- `sql/test/test_12_cortex_ai.sql`
+- `src/app/.ai.md`
+- `src/app/cortex.py`
+- `tests/test_12_cortex_ai.py` (선택)
+
+**리서치 산출물 (팀 `plan-27-cortex`):**
+- `.omc/research/27-plan-spec-alignment.md` — 정정안 15건 + Red 테스트 6 TC + 사전 검증 5개
+- `.omc/research/27-plan-impl-architecture.md` — 3 SQL + cortex.py 전체 본문 + 비용 추정
+- `.omc/research/27-plan-compatibility.md` — 의존성 그래프 + 리스크 10건 + merge 순서
+
+---
+
+*플랜 완성일: 2026-04-08. 다음 단계 → 7.1 준비·검증(Snowflake MCP V0 7건)부터 착수.*

--- a/sql/cortex/.ai.md
+++ b/sql/cortex/.ai.md
@@ -1,0 +1,68 @@
+# sql/cortex — Cortex AI Functions (Issue #27)
+
+## 목적
+Snowflake Cortex AI Functions(AI_COMPLETE / AI_CLASSIFY / AI_AGG / AI_EMBED)를 활용해
+MART_MOVE_ANALYSIS 기반 이사 수요 인사이트·등급 분류·벡터 유사도 검색을 구현하는 SQL 뷰·테이블·SP 모음.
+
+MOVING_INTEL.ANALYTICS 스키마에 객체를 생성하며, Marketplace 원본(RICHGO 등)은 ALTER 없이 참조만 한다.
+
+## 파일 목록
+
+| 파일 | 이슈 | 역할 | 생성 객체 |
+|------|------|------|----------|
+| `001_cortex_ai_insights.sql` | #27 | AI_COMPLETE 구 단위 인사이트 + AI_AGG 시/도 요약 | `V_AI_DISTRICT_INSIGHTS`, `V_AI_STATE_SUMMARY` |
+| `002_cortex_ai_classify.sql` | #27 | AI_CLASSIFY 이사 수요 3등급 분류 | `V_AI_DEMAND_GRADE` |
+| `003_cortex_ai_embed.sql` | #27 | AI_EMBED 지역 프로필 벡터 + 유사도 검색 | `T_DISTRICT_EMBEDDINGS`, `SP_REFRESH_DISTRICT_EMBEDDINGS`, `SP_FIND_SIMILAR_DISTRICTS` |
+
+## 의존성
+
+```
+#16 DDL (MOVING_INTEL.ANALYTICS 스키마)
+#21 MART_MOVE_ANALYSIS         → 001, 002, 003 (핵심 소스 — AVG_MEME_PRICE 등 pre-aggregated 컬럼 포함)
+```
+
+RICHGO/BJD는 #21 `pipelines/preprocessing.py` 단계에서 MART로 흡수되므로 Cortex 레이어에서는 직접 참조하지 않는다.
+
+## Dual-Tier 분기 원칙
+
+MART_MOVE_ANALYSIS의 `DATA_TIER` 컬럼으로 분기한다.
+
+| DATA_TIER | 구 수 | 가용 시그널 | AI 프롬프트 전략 |
+|-----------|------|------------|----------------|
+| `MULTI_SOURCE` | 3구 (중구·영등포·서초) | OPEN_COUNT + ELECTRONICS_FURNITURE_SALES + TOTAL_RESIDENTIAL_POP + NEW_HOUSING_BALANCE_COUNT + AVG_MEME_PRICE | 4종 시그널 종합 → 3줄 정밀 액션 |
+| `TELECOM_ONLY` | 22구 | OPEN_COUNT + AVG_MEME_PRICE (대부분 NULL) | OPEN_COUNT + 전월 대비 → 2줄 경량, "데이터 신뢰도: 근사" 명시 |
+
+분기 위치: SQL `CASE DATA_TIER WHEN 'MULTI_SOURCE' THEN … ELSE …` — Python cortex.py는 배지 부착만 담당.
+
+### 임베딩 Tier별 기준월 (SP_REFRESH_DISTRICT_EMBEDDINGS)
+
+RICHGO/SPH Marketplace 소스는 2024-12까지만 완전하고 통신 시그널은 2026-04까지. 단일 `MAX(STANDARD_YEAR_MONTH)` 사용 시 MULTI_SOURCE 3구의 4종 시그널이 NULL로 찍혀 "정밀Tier인데 0원/0명" 프로필이 됨 → 임베딩 품질 저하.
+
+`SP_REFRESH_DISTRICT_EMBEDDINGS`는 Tier별로 각 구의 **최선의 가용 월**을 사용한다:
+
+| Tier | 기준월 로직 | 실측 (2026-04 현재) |
+|------|------------|--------------------|
+| MULTI_SOURCE | `MAX(YM WHERE AVG_MEME_PRICE IS NOT NULL)` | 202412 |
+| TELECOM_ONLY | `MAX(YM)` 절대 최신 | 202604 |
+
+관측성: `T_DISTRICT_EMBEDDINGS.PROFILE_YM` 컬럼에 각 구가 사용한 월 기록.
+
+## 함수 네임스페이스 불변식
+
+- `AI_COMPLETE` / `AI_CLASSIFY` / `AI_AGG` / `AI_EMBED` / `VECTOR_COSINE_SIMILARITY` (GA, 접두사 없음)
+- `SNOWFLAKE.CORTEX.*` 접두사 사용 **금지**
+- 모델: completion=`claude-4-sonnet`, embed=`snowflake-arctic-embed-l-v2.0`, 벡터 차원=`VECTOR(FLOAT, 1024)`
+- AI_CLASSIFY 라벨: `'긴급'` / `'주의'` / `'안정'` (짧은 형태만 — em-dash 긴 라벨은 empty array 반환)
+- AI_CLASSIFY 추출: `:labels[0]::STRING`
+
+## 실행 시 주의
+
+- 뷰는 SELECT 시점마다 AI_COMPLETE/AI_CLASSIFY/AI_AGG/AI_EMBED 호출 → **전수 SELECT 금지**
+- 검증은 반드시 단일 행 필터(`WHERE CITY_CODE='11680' AND STANDARD_YEAR_MONTH='202604'`)로만 실행
+- Streamlit에서는 `src/app/cortex.py` 파라미터 기반 함수 호출 + `@st.cache_data(ttl=3600)` 사용
+
+## 관련 파일
+
+- `src/app/cortex.py` — Snowpark 헬퍼 4개 함수 (후속 이슈 #28/#29 소비)
+- `sql/test/test_12_cortex_ai.sql` — TC-01~TC-06 검증
+- `docs/work/active/000027-cortex-ai-functions/01_plan.md` — 구현 플랜 SoT

--- a/sql/cortex/001_cortex_ai_insights.sql
+++ b/sql/cortex/001_cortex_ai_insights.sql
@@ -1,0 +1,121 @@
+-- ============================================================
+-- 001_cortex_ai_insights.sql
+-- Cortex AI_COMPLETE + AI_AGG 기반 이사 인사이트 뷰
+-- 이슈: #27 (feat: Cortex AI Functions — AI_COMPLETE/CLASSIFY/EMBED)
+-- 의존성: MART_MOVE_ANALYSIS (#21, pipelines/preprocessing.py)
+--   * AVG_MEME_PRICE 는 MART 내 pre-aggregated 컬럼 — RICHGO 재JOIN 불필요
+-- 멱등성: CREATE OR REPLACE VIEW — 반복 실행 안전 (AI 호출은 SELECT 시점)
+-- 리전: US West (Oregon, us-west-2) — Cortex AI Functions 제한 없음
+--
+-- ⚠ 비용 주의: 뷰 SELECT마다 AI_COMPLETE/AI_AGG 호출 발생
+--   V_AI_DISTRICT_INSIGHTS: 850행 × claude-4-sonnet 호출 위험
+--   V_AI_STATE_SUMMARY:     34월 × AI_AGG 호출 위험
+--   → 반드시 WHERE (CITY_CODE, STANDARD_YEAR_MONTH) 필터 또는
+--     src/app/cortex.py 헬퍼 경유. SELECT * 금지.
+-- ============================================================
+
+-- Step 0: 컨텍스트
+USE WAREHOUSE MOVING_INTEL_WH;
+USE SCHEMA MOVING_INTEL.ANALYTICS;
+
+-- ============================================================
+-- Step 1: V_AI_DISTRICT_INSIGHTS — 25구 × 월 단위 AI 인사이트
+--   DATA_TIER별 분기 프롬프트:
+--     - MULTI_SOURCE(3구): OPEN_COUNT + ELECTRONICS_FURNITURE_SALES
+--                         + TOTAL_RESIDENTIAL_POP + NEW_HOUSING_BALANCE_COUNT
+--                         + 전월 대비 + RICHGO 평당가 → 3줄 정밀 액션
+--     - TELECOM_ONLY(22구): OPEN_COUNT + 전월 대비 + RICHGO 평당가
+--                          → 2줄 경량 + '근사' 신뢰도 고지
+-- ============================================================
+CREATE OR REPLACE VIEW V_AI_DISTRICT_INSIGHTS
+  COMMENT = 'Cortex AI_COMPLETE 기반 구 단위 월별 B2B 인사이트 (Tier 분기) — #27'
+AS
+WITH mart_with_yoy AS (
+    SELECT
+        m.CITY_CODE,
+        m.CITY_KOR_NAME,
+        m.STANDARD_YEAR_MONTH,
+        m.DATA_TIER,
+        m.OPEN_COUNT,
+        m.ELECTRONICS_FURNITURE_SALES,
+        m.TOTAL_RESIDENTIAL_POP,
+        m.NEW_HOUSING_BALANCE_COUNT,
+        m.AVG_MEME_PRICE,
+        LAG(m.OPEN_COUNT) OVER (
+            PARTITION BY m.CITY_CODE ORDER BY m.STANDARD_YEAR_MONTH
+        ) AS PREV_OPEN_COUNT,
+        ROUND(
+            (m.OPEN_COUNT - LAG(m.OPEN_COUNT) OVER (
+                PARTITION BY m.CITY_CODE ORDER BY m.STANDARD_YEAR_MONTH
+            )) / NULLIF(LAG(m.OPEN_COUNT) OVER (
+                PARTITION BY m.CITY_CODE ORDER BY m.STANDARD_YEAR_MONTH
+            ), 0) * 100, 1
+        ) AS YOY_PCT
+    FROM MOVING_INTEL.ANALYTICS.MART_MOVE_ANALYSIS m
+)
+SELECT
+    mwy.CITY_CODE,
+    mwy.CITY_KOR_NAME,
+    mwy.STANDARD_YEAR_MONTH,
+    mwy.DATA_TIER,
+    mwy.OPEN_COUNT,
+    mwy.PREV_OPEN_COUNT,
+    mwy.YOY_PCT,
+    mwy.AVG_MEME_PRICE,
+    AI_COMPLETE(
+        'claude-4-sonnet',
+        CASE mwy.DATA_TIER
+          WHEN 'MULTI_SOURCE' THEN
+            CONCAT(
+                '[정밀 Tier] 서울 ', mwy.CITY_KOR_NAME, ' ',
+                mwy.STANDARD_YEAR_MONTH, ' 기준 이사 시그널 ',
+                '종합 분석: 신규 통신 개통(이사 프록시) ', COALESCE(mwy.OPEN_COUNT, 0), '건, ',
+                '전월 대비 ', COALESCE(TO_CHAR(mwy.YOY_PCT), 'N/A'), '%, ',
+                '가전/가구 카드매출 ', COALESCE(TO_CHAR(mwy.ELECTRONICS_FURNITURE_SALES), '0'), '원, ',
+                '상주 인구 ', COALESCE(TO_CHAR(mwy.TOTAL_RESIDENTIAL_POP), '0'), '명, ',
+                '신규 주거 잔고 ', COALESCE(TO_CHAR(mwy.NEW_HOUSING_BALANCE_COUNT), '0'), '건, ',
+                '평당 아파트 매매가 ', COALESCE(TO_CHAR(ROUND(mwy.AVG_MEME_PRICE)), 'N/A'), '원. ',
+                '4종 시그널을 종합해 B2B 마케팅 담당자(가전 렌탈·이사·인테리어)에게 ',
+                '정확히 3줄의 액션 아이템을 한국어로 제안하세요. ',
+                '각 줄은 번호(1., 2., 3.)로 시작하고, 구체적 수치·세그먼트·채널을 포함하세요.'
+            )
+          ELSE  -- 'TELECOM_ONLY'
+            CONCAT(
+                '[근사 Tier] 서울 ', mwy.CITY_KOR_NAME, ' ',
+                mwy.STANDARD_YEAR_MONTH, ' 기준 이사 시그널 ',
+                '경량 분석 (데이터 신뢰도: 근사 — 통신 신호 단일 소스): ',
+                '신규 통신 개통(이사 프록시) ', COALESCE(mwy.OPEN_COUNT, 0), '건, ',
+                '전월 대비 ', COALESCE(TO_CHAR(mwy.YOY_PCT), 'N/A'), '%, ',
+                '평당 아파트 매매가 ', COALESCE(TO_CHAR(ROUND(mwy.AVG_MEME_PRICE)), 'N/A'), '원. ',
+                '통신 신호만을 기반으로 한 경량 인사이트를 정확히 2줄의 한국어로 제시하세요. ',
+                '첫 줄에 반드시 "데이터 신뢰도: 근사 (통신 단일 소스)"를 포함하고, ',
+                '두 번째 줄에 실행 가능한 액션 아이템 1개를 제시하세요.'
+            )
+        END
+    ) AS AI_INSIGHT
+FROM mart_with_yoy mwy;
+
+-- ============================================================
+-- Step 2: V_AI_STATE_SUMMARY — AI_AGG 시/도 단위 자연어 트렌드 요약
+--   서울 25구 전체를 한 번에 집약 (월별)
+-- ============================================================
+CREATE OR REPLACE VIEW V_AI_STATE_SUMMARY
+  COMMENT = 'Cortex AI_AGG 기반 서울 25구 월별 트렌드 자연어 요약 — #27'
+AS
+SELECT
+    '서울' AS INSTALL_STATE,
+    m.STANDARD_YEAR_MONTH,
+    COUNT(DISTINCT m.CITY_CODE) AS DISTRICT_COUNT,
+    SUM(m.OPEN_COUNT) AS TOTAL_OPEN_COUNT,
+    AI_AGG(
+        CONCAT(
+            m.CITY_KOR_NAME, ' (', m.DATA_TIER, '): 신규개통 ',
+            COALESCE(TO_CHAR(m.OPEN_COUNT), '0'), '건'
+        ),
+        '이 시/도의 구별 이사 수요(신규 통신 개통 기준) 트렌드를 ' ||
+        '2~3문장의 한국어로 요약하세요. ' ||
+        '반드시 (1) 수요가 가장 높은 구 1개, (2) 수요가 가장 낮은 구 1개, ' ||
+        '(3) MULTI_SOURCE Tier 3구의 특징 한 줄을 포함하세요.'
+    ) AS STATE_SUMMARY
+FROM MOVING_INTEL.ANALYTICS.MART_MOVE_ANALYSIS m
+GROUP BY m.STANDARD_YEAR_MONTH;

--- a/sql/cortex/002_cortex_ai_classify.sql
+++ b/sql/cortex/002_cortex_ai_classify.sql
@@ -1,0 +1,74 @@
+-- ============================================================
+-- 002_cortex_ai_classify.sql
+-- Cortex AI_CLASSIFY 기반 이사 수요 등급 분류 뷰
+-- 이슈: #27 (feat: Cortex AI Functions — AI_COMPLETE/CLASSIFY/EMBED)
+-- 의존성: MART_MOVE_ANALYSIS (#21, pipelines/preprocessing.py)
+-- 멱등성: CREATE OR REPLACE VIEW — 반복 실행 안전 (AI 호출은 SELECT 시점)
+-- 리전: US West (Oregon, us-west-2)
+--
+-- ⚠ 비용 주의: SELECT마다 AI_CLASSIFY 호출
+--   V_AI_DEMAND_GRADE: 850행 × claude-4-sonnet 호출 위험
+--   → 반드시 WHERE (CITY_CODE, STANDARD_YEAR_MONTH) 필터 또는
+--     src/app/cortex.py:classify_demand 경유. SELECT * 금지.
+-- ============================================================
+-- AI_CLASSIFY 라벨 제약 (V6 실측 확정):
+--   짧은 라벨만 허용: '긴급' / '주의' / '안정'
+--   em-dash 긴 라벨('긴급 — 즉시 마케팅 투입' 등)은 empty array 반환 → 금지
+--   추출 경로: :labels[0]::STRING (dev_spec ':label::STRING' 표기는 오류)
+-- ============================================================
+
+-- Step 0: 컨텍스트
+USE WAREHOUSE MOVING_INTEL_WH;
+USE SCHEMA MOVING_INTEL.ANALYTICS;
+
+-- ============================================================
+-- V_AI_DEMAND_GRADE — 25구 × 월 단위 3등급 분류
+--   입력: 서울 구명 + STANDARD_YEAR_MONTH + 신규개통 건수 + 전월 대비 변화율
+--   출력 DEMAND_GRADE: '긴급' | '주의' | '안정' (NULL이면 '알수없음' fallback)
+-- ============================================================
+CREATE OR REPLACE VIEW V_AI_DEMAND_GRADE
+  COMMENT = 'Cortex AI_CLASSIFY 기반 25구 월별 이사 수요 등급 — #27'
+AS
+-- YOY_PCT는 SELECT 프로젝션과 AI_CLASSIFY 프롬프트 양쪽에서 사용되므로
+-- 중간 CTE에서 한 번만 계산해 drift를 방지한다.
+WITH with_yoy AS (
+    SELECT
+        m.CITY_CODE,
+        m.CITY_KOR_NAME,
+        m.STANDARD_YEAR_MONTH,
+        m.DATA_TIER,
+        m.OPEN_COUNT,
+        LAG(m.OPEN_COUNT) OVER (
+            PARTITION BY m.CITY_CODE ORDER BY m.STANDARD_YEAR_MONTH
+        ) AS PREV_OPEN_COUNT,
+        ROUND(
+            (m.OPEN_COUNT - LAG(m.OPEN_COUNT) OVER (
+                PARTITION BY m.CITY_CODE ORDER BY m.STANDARD_YEAR_MONTH
+            )) / NULLIF(LAG(m.OPEN_COUNT) OVER (
+                PARTITION BY m.CITY_CODE ORDER BY m.STANDARD_YEAR_MONTH
+            ), 0) * 100, 1
+        ) AS YOY_PCT
+    FROM MOVING_INTEL.ANALYTICS.MART_MOVE_ANALYSIS m
+)
+SELECT
+    wy.CITY_CODE,
+    wy.CITY_KOR_NAME,
+    wy.STANDARD_YEAR_MONTH,
+    wy.DATA_TIER,
+    wy.OPEN_COUNT,
+    wy.PREV_OPEN_COUNT,
+    wy.YOY_PCT,
+    COALESCE(
+        AI_CLASSIFY(
+            CONCAT(
+                '서울 ', wy.CITY_KOR_NAME, ', ',
+                wy.STANDARD_YEAR_MONTH, ', 신규개통 ',
+                COALESCE(TO_CHAR(wy.OPEN_COUNT), '0'), '건, 전월 대비 ',
+                COALESCE(TO_CHAR(wy.YOY_PCT), 'N/A'), '%'
+            ),
+            ARRAY_CONSTRUCT('긴급', '주의', '안정')
+        ):labels[0]::STRING,
+        '알수없음'
+    ) AS DEMAND_GRADE
+FROM with_yoy wy
+WHERE wy.OPEN_COUNT IS NOT NULL;

--- a/sql/cortex/003_cortex_ai_embed.sql
+++ b/sql/cortex/003_cortex_ai_embed.sql
@@ -1,0 +1,185 @@
+-- ============================================================
+-- 003_cortex_ai_embed.sql
+-- Cortex AI_EMBED 기반 지역 프로필 벡터 테이블 + 유사도 검색 SP
+-- 이슈: #27 (feat: Cortex AI Functions — AI_COMPLETE/CLASSIFY/EMBED)
+-- 의존성: MART_MOVE_ANALYSIS (#21, pipelines/preprocessing.py)
+-- 전략: Marketplace 원본 ALTER 금지 (read-only) → MOVING_INTEL.ANALYTICS 에 별도 테이블
+-- 멱등성: CREATE TABLE IF NOT EXISTS + CREATE OR REPLACE PROCEDURE + MERGE INTO
+-- 리전: US West (Oregon, us-west-2) — snowflake-arctic-embed-l-v2.0 → VECTOR(FLOAT, 1024)
+-- ============================================================
+
+-- Step 0: 컨텍스트
+USE WAREHOUSE MOVING_INTEL_WH;
+USE SCHEMA MOVING_INTEL.ANALYTICS;
+
+-- ============================================================
+-- Step 1: T_DISTRICT_EMBEDDINGS — 25구 지역 프로필 벡터 저장 테이블
+--   크기: 25행 × 1024 float ≈ 100 KB (부담 없음)
+--   EMBEDDING 컬럼: VECTOR(FLOAT, 1024) — snowflake-arctic-embed-l-v2.0 차원
+--   PROFILE_YM: 각 구 임베딩이 기반으로 한 월 — Tier별로 다를 수 있음
+--     (MULTI_SOURCE: RICHGO/SPH 4종 시그널 non-null 최신월
+--      TELECOM_ONLY: 통신 기준 최신월)
+-- ============================================================
+CREATE TABLE IF NOT EXISTS MOVING_INTEL.ANALYTICS.T_DISTRICT_EMBEDDINGS (
+    CITY_CODE       VARCHAR(5)    NOT NULL,
+    CITY_KOR_NAME   VARCHAR(50)   NOT NULL,
+    DATA_TIER       VARCHAR(20)   NOT NULL,
+    PROFILE_YM      VARCHAR(6),                 -- 임베딩 기준월 (Tier별 분기)
+    PROFILE_TEXT    VARCHAR(4000),              -- 디버깅용 원문 텍스트
+    EMBEDDING       VECTOR(FLOAT, 1024),        -- AI_EMBED 결과
+    UPDATED_AT      TIMESTAMP_NTZ DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT PK_T_DISTRICT_EMBEDDINGS PRIMARY KEY (CITY_CODE)
+)
+COMMENT = 'Cortex AI_EMBED 지역 프로필 벡터 (서울 25구) — #27';
+
+-- ============================================================
+-- Step 2: SP_REFRESH_DISTRICT_EMBEDDINGS
+--   Tier별 기준월 분기 — 각 구에 가용한 최선의 월로 프로필 생성.
+--
+--   배경: RICHGO/SPH Marketplace 소스는 2024-12까지만 완전하고
+--   통신(V_TELECOM_NEW_INSTALL)은 2026-04까지. MART_MOVE_ANALYSIS의
+--   `MAX(STANDARD_YEAR_MONTH)`만 쓰면 MULTI_SOURCE 3구(중구·영등포·서초)의
+--   평당가·인구·카드매출·신규주거잔고가 전부 NULL이 되어 "정밀Tier인데 0"인
+--   이상한 프로필 텍스트가 생긴다.
+--
+--   분기 전략:
+--     multi_ym   = MAX(YM WHERE DATA_TIER='MULTI_SOURCE' AND AVG_MEME_PRICE NOT NULL)
+--     telecom_ym = MAX(YM WHERE DATA_TIER='TELECOM_ONLY')
+--     MULTI_SOURCE 3구: multi_ym 의 4종 시그널 + 평당가 (정밀 프로필)
+--     TELECOM_ONLY 22구: telecom_ym 의 신규개통 (근사 프로필)
+--
+--   멱등성: MERGE INTO (UPDATE/INSERT)
+--   관측성: PROFILE_YM 컬럼에 각 구가 사용한 월 기록
+-- ============================================================
+CREATE OR REPLACE PROCEDURE MOVING_INTEL.ANALYTICS.SP_REFRESH_DISTRICT_EMBEDDINGS()
+RETURNS STRING
+LANGUAGE SQL
+AS
+$$
+DECLARE
+    multi_ym   VARCHAR;
+    telecom_ym VARCHAR;
+    row_count  INT;
+BEGIN
+    -- MULTI_SOURCE: 4종 시그널(평당가) 살아있는 최신월
+    SELECT MAX(STANDARD_YEAR_MONTH) INTO :multi_ym
+    FROM MOVING_INTEL.ANALYTICS.MART_MOVE_ANALYSIS
+    WHERE DATA_TIER = 'MULTI_SOURCE'
+      AND AVG_MEME_PRICE IS NOT NULL;
+
+    -- TELECOM_ONLY: 통신 신규개통 기준 절대 최신월
+    SELECT MAX(STANDARD_YEAR_MONTH) INTO :telecom_ym
+    FROM MOVING_INTEL.ANALYTICS.MART_MOVE_ANALYSIS
+    WHERE DATA_TIER = 'TELECOM_ONLY';
+
+    MERGE INTO MOVING_INTEL.ANALYTICS.T_DISTRICT_EMBEDDINGS tgt
+    USING (
+        WITH profile AS (
+            SELECT
+                m.CITY_CODE,
+                m.CITY_KOR_NAME,
+                m.DATA_TIER,
+                m.STANDARD_YEAR_MONTH AS PROFILE_YM,
+                CASE m.DATA_TIER
+                  WHEN 'MULTI_SOURCE' THEN
+                    CONCAT(
+                        '서울 ', m.CITY_KOR_NAME,
+                        ', 기준월 ', m.STANDARD_YEAR_MONTH,
+                        ', 정밀Tier 4종시그널, 신규개통 ',
+                        COALESCE(TO_CHAR(m.OPEN_COUNT), '0'), '건, ',
+                        '상주인구 ',
+                        COALESCE(TO_CHAR(ROUND(m.TOTAL_RESIDENTIAL_POP)), '0'), '명, ',
+                        '가전가구매출 ',
+                        COALESCE(TO_CHAR(m.ELECTRONICS_FURNITURE_SALES), '0'), '원, ',
+                        '신규주거잔고 ',
+                        COALESCE(TO_CHAR(m.NEW_HOUSING_BALANCE_COUNT), '0'), '건, ',
+                        '평당매매가 ',
+                        COALESCE(TO_CHAR(ROUND(m.AVG_MEME_PRICE)), 'N/A'), '원'
+                    )
+                  ELSE
+                    CONCAT(
+                        '서울 ', m.CITY_KOR_NAME,
+                        ', 기준월 ', m.STANDARD_YEAR_MONTH,
+                        ', 근사Tier 통신단일, 신규개통 ',
+                        COALESCE(TO_CHAR(m.OPEN_COUNT), '0'), '건'
+                    )
+                END AS PROFILE_TEXT
+            FROM MOVING_INTEL.ANALYTICS.MART_MOVE_ANALYSIS m
+            WHERE (m.DATA_TIER = 'MULTI_SOURCE' AND m.STANDARD_YEAR_MONTH = :multi_ym)
+               OR (m.DATA_TIER = 'TELECOM_ONLY' AND m.STANDARD_YEAR_MONTH = :telecom_ym)
+        )
+        SELECT
+            p.CITY_CODE,
+            p.CITY_KOR_NAME,
+            p.DATA_TIER,
+            p.PROFILE_YM,
+            p.PROFILE_TEXT,
+            AI_EMBED('snowflake-arctic-embed-l-v2.0', p.PROFILE_TEXT) AS EMBEDDING
+        FROM profile p
+    ) src
+    ON tgt.CITY_CODE = src.CITY_CODE
+    WHEN MATCHED THEN UPDATE SET
+        CITY_KOR_NAME = src.CITY_KOR_NAME,
+        DATA_TIER     = src.DATA_TIER,
+        PROFILE_YM    = src.PROFILE_YM,
+        PROFILE_TEXT  = src.PROFILE_TEXT,
+        EMBEDDING     = src.EMBEDDING,
+        UPDATED_AT    = CURRENT_TIMESTAMP
+    WHEN NOT MATCHED THEN INSERT
+        (CITY_CODE, CITY_KOR_NAME, DATA_TIER, PROFILE_YM, PROFILE_TEXT, EMBEDDING, UPDATED_AT)
+    VALUES
+        (src.CITY_CODE, src.CITY_KOR_NAME, src.DATA_TIER, src.PROFILE_YM,
+         src.PROFILE_TEXT, src.EMBEDDING, CURRENT_TIMESTAMP);
+
+    SELECT COUNT(*) INTO :row_count
+    FROM MOVING_INTEL.ANALYTICS.T_DISTRICT_EMBEDDINGS;
+
+    RETURN 'T_DISTRICT_EMBEDDINGS refreshed (multi_ym=' || :multi_ym
+           || ', telecom_ym=' || :telecom_ym
+           || ', rows=' || :row_count || ')';
+END;
+$$;
+
+-- ============================================================
+-- Step 3: SP_FIND_SIMILAR_DISTRICTS(TARGET_CITY_CODE, TOP_K)
+--   VECTOR_COSINE_SIMILARITY 기반 유사 구 top_k 반환 (타겟 자신 제외)
+--   반환: TABLE(CITY_CODE, CITY_KOR_NAME, DATA_TIER, SIMILARITY)
+-- ============================================================
+CREATE OR REPLACE PROCEDURE MOVING_INTEL.ANALYTICS.SP_FIND_SIMILAR_DISTRICTS(
+    TARGET_CITY_CODE VARCHAR,
+    TOP_K NUMBER
+)
+RETURNS TABLE (
+    CITY_CODE     VARCHAR,
+    CITY_KOR_NAME VARCHAR,
+    DATA_TIER     VARCHAR,
+    SIMILARITY    FLOAT
+)
+LANGUAGE SQL
+AS
+$$
+DECLARE
+    res RESULTSET;
+BEGIN
+    res := (
+        SELECT
+            similar.CITY_CODE,
+            similar.CITY_KOR_NAME,
+            similar.DATA_TIER,
+            VECTOR_COSINE_SIMILARITY(target.EMBEDDING, similar.EMBEDDING)::FLOAT AS SIMILARITY
+        FROM MOVING_INTEL.ANALYTICS.T_DISTRICT_EMBEDDINGS target
+        CROSS JOIN MOVING_INTEL.ANALYTICS.T_DISTRICT_EMBEDDINGS similar
+        WHERE target.CITY_CODE = :TARGET_CITY_CODE
+          AND similar.CITY_CODE <> target.CITY_CODE
+        ORDER BY SIMILARITY DESC
+        LIMIT :TOP_K
+    );
+    RETURN TABLE(res);
+END;
+$$;
+
+-- ============================================================
+-- Step 4: 초기 로드 — 배포 시 1회 실행
+--   25구 × AI_EMBED 호출 → T_DISTRICT_EMBEDDINGS 25행 채움
+-- ============================================================
+CALL MOVING_INTEL.ANALYTICS.SP_REFRESH_DISTRICT_EMBEDDINGS();

--- a/sql/test/test_12_cortex_ai.sql
+++ b/sql/test/test_12_cortex_ai.sql
@@ -1,0 +1,56 @@
+-- ============================================================
+-- test_12_cortex_ai.sql
+-- Cortex AI Functions 검증 (TC-01 ~ TC-06) — 이슈 #27
+-- SoT: docs/specs/dev_spec.md B4 (#40 재작성본)
+-- 모델: claude-4-sonnet, snowflake-arctic-embed-l-v2.0
+-- 전제: Oregon, MART_MOVE_ANALYSIS(#21), V_TELECOM_NEW_INSTALL(#19)
+-- ============================================================
+
+USE WAREHOUSE MOVING_INTEL_WH;
+USE SCHEMA MOVING_INTEL.ANALYTICS;
+
+-- TC-01: AI_COMPLETE 기본 호출
+SELECT LEFT(AI_COMPLETE('claude-4-sonnet', '한국어로 "안녕하세요"라고만 답하세요.'), 30) AS hello;
+-- EXPECTED: LENGTH > 0
+
+-- TC-02: AI_CLASSIFY 3등급 분류 + :labels[0]::STRING 추출
+SELECT AI_CLASSIFY(
+    '신규개통 150건, 전월 대비 25 퍼센트 증가',
+    ARRAY_CONSTRUCT('긴급', '주의', '안정')
+):labels[0]::STRING AS grade;
+-- EXPECTED: {'긴급','주의','안정'} 중 하나
+
+-- TC-03: AI_EMBED NOT NULL (TYPEOF/VECTOR_DIMENSION 미지원이므로 NOT NULL + 간접 확인)
+SELECT AI_EMBED('snowflake-arctic-embed-l-v2.0', '서울 강남구 아파트 평당 1200만원') IS NOT NULL AS ok;
+-- EXPECTED: TRUE (VECTOR(FLOAT, 1024))
+
+-- TC-04: 실데이터 + AI_COMPLETE
+SELECT v.INSTALL_CITY, v.OPEN_COUNT,
+       LEFT(AI_COMPLETE('claude-4-sonnet',
+            CONCAT('서울 ', v.INSTALL_CITY, ' 신규 통신 개통 ', v.OPEN_COUNT, '건. 2줄 액션 아이템을 한국어로.')), 100) AS insight
+FROM MOVING_INTEL.ANALYTICS.V_TELECOM_NEW_INSTALL v
+WHERE v.INSTALL_STATE = '서울'
+  AND v.OPEN_COUNT IS NOT NULL
+ORDER BY v.OPEN_COUNT DESC LIMIT 1;
+-- EXPECTED: 1행, insight LENGTH > 0
+
+-- TC-05: VECTOR_COSINE_SIMILARITY
+WITH e AS (
+    SELECT AI_EMBED('snowflake-arctic-embed-l-v2.0', '서울 강남구 아파트 단지') AS v1,
+           AI_EMBED('snowflake-arctic-embed-l-v2.0', '서울 서초구 아파트 단지') AS v2,
+           AI_EMBED('snowflake-arctic-embed-l-v2.0', '부산 해운대 오피스텔') AS v3
+)
+SELECT VECTOR_COSINE_SIMILARITY(v1, v2) AS sim_gn_sc,
+       VECTOR_COSINE_SIMILARITY(v1, v3) AS sim_gn_hu
+FROM e;
+-- EXPECTED: 둘 다 FLOAT NOT NULL, sim_gn_sc >= sim_gn_hu (자연스러움)
+
+-- TC-06: AI_AGG MART 기반
+SELECT '서울' AS region, LEFT(
+    AI_AGG(
+        CONCAT(m.CITY_KOR_NAME, ' (', m.DATA_TIER, '): 신규개통 ', COALESCE(TO_CHAR(m.OPEN_COUNT),'0'), '건'),
+        '서울 25구 월별 이사(신규개통) 트렌드를 2문장 한국어로 요약. 가장 높은 구와 낮은 구 지목.'
+    ), 200) AS summary
+FROM MOVING_INTEL.ANALYTICS.MART_MOVE_ANALYSIS m
+WHERE m.STANDARD_YEAR_MONTH = '202603';
+-- EXPECTED: 1행, summary LENGTH > 0

--- a/src/app/.ai.md
+++ b/src/app/.ai.md
@@ -1,0 +1,40 @@
+# src/app — Streamlit 앱 루트
+
+## 목적
+
+Snowflake Cortex AI Functions 기반 이사 수요 분석 Streamlit 앱의 루트 디렉토리.
+
+이 이슈(#27)에서는 `cortex.py` 헬퍼 모듈만 추가한다.
+탭·컴포넌트·UI 레이아웃은 후속 이슈(#28 히트맵, #29 세그먼트)에서 구현한다.
+
+## 파일 구조
+
+```
+src/app/
+├── .ai.md          이 파일 — 디렉토리 목적·구조
+└── cortex.py       Snowpark 기반 Cortex AI 헬퍼 4 함수 (#27)
+```
+
+## cortex.py 공개 API
+
+| 함수 | 용도 | 소비 이슈 |
+|------|------|-----------|
+| `get_district_insight(session, city_code, year_month)` | V_AI_DISTRICT_INSIGHTS 단일 행 조회 | #28 히트맵 상세 패널 |
+| `classify_demand(session, city_code, year_month)` | V_AI_DEMAND_GRADE 단일 행 조회 | #28 색상/범례 |
+| `find_similar_districts(session, city_code, top_k=5)` | SP_FIND_SIMILAR_DISTRICTS 호출 | #29 유사 지역 탭 |
+| `aggregate_state_summary(session, year_month)` | V_AI_STATE_SUMMARY 단일 월 조회 | #29 보조 카드 |
+
+## 의존성
+
+- `MOVING_INTEL.ANALYTICS.V_AI_DISTRICT_INSIGHTS` — #27
+- `MOVING_INTEL.ANALYTICS.V_AI_DEMAND_GRADE` — #27
+- `MOVING_INTEL.ANALYTICS.V_AI_STATE_SUMMARY` — #27
+- `MOVING_INTEL.ANALYTICS.SP_FIND_SIMILAR_DISTRICTS` — #27
+- `snowflake-snowpark-python` — Streamlit in Snowflake 내장 또는 로컬 설치
+
+## 보안 불변식
+
+- 서울 25구 CITY_CODE allowlist (`SEOUL_CITY_CODES`) 강제 검증
+- YYYYMM 6자리 숫자 정규식 검증
+- `session.sql(..., params=[...])` bind 파라미터 — f-string SQL 금지
+- Snowflake 계정 정보 하드코딩 금지 (connections.toml / st.connection() 사용)

--- a/src/app/cortex.py
+++ b/src/app/cortex.py
@@ -1,0 +1,158 @@
+"""cortex.py — Snowflake Cortex AI Functions 헬퍼 (이슈 #27)"""
+from __future__ import annotations
+from typing import TypedDict
+from snowflake.snowpark import Session
+
+# 서울 25구 CITY_CODE allowlist (실데이터 검증 기반)
+# Tier 분류(MULTI_SOURCE 3구 vs TELECOM_ONLY 22구)는 MART_MOVE_ANALYSIS.DATA_TIER
+# 컬럼에서 읽어오므로 Python 측에서는 별도 리스트로 보관하지 않는다.
+SEOUL_CITY_CODES: frozenset[str] = frozenset({
+    "11110", "11140", "11170", "11200", "11215", "11230", "11260", "11290", "11305",
+    "11320", "11350", "11380", "11410", "11440", "11470", "11500", "11530", "11545",
+    "11560", "11590", "11620", "11650", "11680", "11710", "11740",
+})
+
+TIER_BADGE: dict[str, str] = {
+    "MULTI_SOURCE": "정밀 Tier (4종 시그널)",
+    "TELECOM_ONLY": "근사 Tier (통신 단일)",
+}
+
+
+def _validate_city_code(city_code: str) -> str:
+    if city_code not in SEOUL_CITY_CODES:
+        raise ValueError(f"Invalid city_code: {city_code!r}")
+    return city_code
+
+
+def _validate_year_month(ym: str) -> str:
+    # 형식: YYYYMM (6자리 ASCII 숫자, 월 01-12)
+    if not (isinstance(ym, str) and len(ym) == 6 and ym.isascii() and ym.isdigit()):
+        raise ValueError(f"Invalid year_month: {ym!r} (expected YYYYMM)")
+    month = int(ym[4:])
+    if not 1 <= month <= 12:
+        raise ValueError(f"Invalid year_month: {ym!r} (month must be 01-12)")
+    return ym
+
+
+class DistrictInsight(TypedDict):
+    city_code: str
+    city_name: str
+    data_tier: str
+    tier_badge: str
+    year_month: str
+    open_count: int | None
+    yoy_pct: float | None
+    ai_insight: str
+
+
+class DemandGrade(TypedDict):
+    city_code: str
+    city_name: str
+    data_tier: str
+    tier_badge: str
+    year_month: str
+    demand_grade: str
+
+
+class SimilarDistrict(TypedDict):
+    city_code: str
+    city_name: str
+    data_tier: str
+    tier_badge: str
+    similarity: float
+
+
+def get_district_insight(session: Session, city_code: str, year_month: str) -> DistrictInsight:
+    """V_AI_DISTRICT_INSIGHTS 단일 행 조회."""
+    city_code = _validate_city_code(city_code)
+    year_month = _validate_year_month(year_month)
+    rows = session.sql(
+        """
+        SELECT CITY_CODE, CITY_KOR_NAME, DATA_TIER, STANDARD_YEAR_MONTH,
+               OPEN_COUNT, YOY_PCT, AI_INSIGHT
+        FROM MOVING_INTEL.ANALYTICS.V_AI_DISTRICT_INSIGHTS
+        WHERE CITY_CODE = ? AND STANDARD_YEAR_MONTH = ?
+        """,
+        params=[city_code, year_month],
+    ).collect()
+    if not rows:
+        raise RuntimeError(f"No insight for {city_code} / {year_month}")
+    r = rows[0]
+    tier = r["DATA_TIER"]
+    return DistrictInsight(
+        city_code=r["CITY_CODE"],
+        city_name=r["CITY_KOR_NAME"],
+        data_tier=tier,
+        tier_badge=TIER_BADGE[tier],
+        year_month=r["STANDARD_YEAR_MONTH"],
+        open_count=r["OPEN_COUNT"],
+        yoy_pct=r["YOY_PCT"],
+        ai_insight=r["AI_INSIGHT"],
+    )
+
+
+def classify_demand(session: Session, city_code: str, year_month: str) -> DemandGrade:
+    """V_AI_DEMAND_GRADE 단일 행 조회."""
+    city_code = _validate_city_code(city_code)
+    year_month = _validate_year_month(year_month)
+    rows = session.sql(
+        """
+        SELECT CITY_CODE, CITY_KOR_NAME, DATA_TIER, STANDARD_YEAR_MONTH, DEMAND_GRADE
+        FROM MOVING_INTEL.ANALYTICS.V_AI_DEMAND_GRADE
+        WHERE CITY_CODE = ? AND STANDARD_YEAR_MONTH = ?
+        """,
+        params=[city_code, year_month],
+    ).collect()
+    if not rows:
+        raise RuntimeError(f"No grade for {city_code} / {year_month}")
+    r = rows[0]
+    tier = r["DATA_TIER"]
+    return DemandGrade(
+        city_code=r["CITY_CODE"],
+        city_name=r["CITY_KOR_NAME"],
+        data_tier=tier,
+        tier_badge=TIER_BADGE[tier],
+        year_month=r["STANDARD_YEAR_MONTH"],
+        demand_grade=r["DEMAND_GRADE"] or "알수없음",
+    )
+
+
+def find_similar_districts(
+    session: Session, city_code: str, top_k: int = 5
+) -> list[SimilarDistrict]:
+    """SP_FIND_SIMILAR_DISTRICTS(target, top_k) 호출."""
+    city_code = _validate_city_code(city_code)
+    if not (1 <= top_k <= 24):
+        raise ValueError(f"top_k must be 1..24, got {top_k}")
+    rows = session.sql(
+        "CALL MOVING_INTEL.ANALYTICS.SP_FIND_SIMILAR_DISTRICTS(?, ?)",
+        params=[city_code, top_k],
+    ).collect()
+    result: list[SimilarDistrict] = []
+    for r in rows:
+        tier = r["DATA_TIER"]
+        result.append(SimilarDistrict(
+            city_code=r["CITY_CODE"],
+            city_name=r["CITY_KOR_NAME"],
+            data_tier=tier,
+            tier_badge=TIER_BADGE[tier],
+            similarity=float(r["SIMILARITY"]),
+        ))
+    return result
+
+
+def aggregate_state_summary(
+    session: Session, year_month: str, install_state: str = "서울"
+) -> str:
+    """V_AI_STATE_SUMMARY 단일 월 조회."""
+    year_month = _validate_year_month(year_month)
+    if install_state not in {"서울"}:
+        raise ValueError(f"install_state not supported: {install_state!r}")
+    rows = session.sql(
+        """SELECT STATE_SUMMARY FROM MOVING_INTEL.ANALYTICS.V_AI_STATE_SUMMARY
+           WHERE STANDARD_YEAR_MONTH = ?""",
+        params=[year_month],
+    ).collect()
+    if not rows:
+        raise RuntimeError(f"No state summary for {year_month}")
+    return rows[0]["STATE_SUMMARY"]


### PR DESCRIPTION
## Summary

- **V_AI_DISTRICT_INSIGHTS**: AI_COMPLETE(claude-4-sonnet) 기반 25구 월별 인사이트. Dual-Tier 분기(MULTI_SOURCE 4종 시그널 정밀 프롬프트 / TELECOM_ONLY 경량 프롬프트)
- **V_AI_STATE_SUMMARY**: AI_AGG 기반 서울 시/도 요약
- **V_AI_DEMAND_GRADE**: AI_CLASSIFY 기반 3등급(긴급/주의/안정) 분류. with_yoy CTE로 YOY_PCT 중복 계산 제거
- **T_DISTRICT_EMBEDDINGS + SP_REFRESH**: AI_EMBED(snowflake-arctic-embed-l-v2.0, 1024dim) 25구 프로필 벡터. Tier-aware 기준월 분기(MULTI_SOURCE=202412, TELECOM_ONLY=202604)
- **SP_FIND_SIMILAR_DISTRICTS**: VECTOR_COSINE_SIMILARITY top-k 유사 구 검색
- **src/app/cortex.py**: Snowpark 헬퍼 4함수 + 입력 검증(_validate_city_code / _validate_year_month)

## Tier-aware 임베딩 핵심

RICHGO/SPH Marketplace 소스는 2024-12까지만 완전 → 단순 MAX(YM)=202604 사용 시 MULTI_SOURCE 3구의 4종 시그널이 모두 NULL이 되어 임베딩 품질 저하. SP에서 Tier별 최선월 분기:

| Tier | 기준월 | 비고 |
|------|--------|------|
| MULTI_SOURCE (중구·영등포·서초) | 202412 | AVG_MEME_PRICE IS NOT NULL 최신월 |
| TELECOM_ONLY (22구) | 202604 | 절대 최신월 |

## Acceptance Criteria

- [x] AC-01 V_AI_DISTRICT_INSIGHTS — MULTI_SOURCE/TELECOM_ONLY 분기 정상
- [x] AC-02 V_AI_STATE_SUMMARY — AI_AGG 25구 집계 요약 반환
- [x] AC-03 V_AI_DEMAND_GRADE — AI_CLASSIFY 3등급(긴급/주의/안정) 분류
- [x] AC-04 src/app/cortex.py 헬퍼 4함수 + 검증 로직
- [x] AC-05 T_DISTRICT_EMBEDDINGS 25행 × VECTOR(FLOAT,1024) 채움
- [x] AC-06 SP_FIND_SIMILAR_DISTRICTS top-k 코사인 유사도 정상 반환

## Test Plan

- [x] TC-01~TC-06 `sql/test/test_12_cortex_ai.sql` 전 케이스 PASS (Snowflake 실행 검증)
- [x] AC-04 smoke `.omc/research/scratch-27/smoke_cortex_helpers.py` 19/19 PASS
- [x] T_DISTRICT_EMBEDDINGS 25행 확인
- [x] SP_FIND_SIMILAR_DISTRICTS 5행 반환 + 타겟 자신 제외 확인

Closes #27

🤖 Generated with [Claude Code](https://claude.com/claude-code)